### PR TITLE
Add bort.properties flag to allow metered OTA check and update

### DIFF
--- a/MemfaultPackages/bort-ota-lib/src/main/java/com/memfault/bort/ota/lib/BootCompleteReceiver.kt
+++ b/MemfaultPackages/bort-ota-lib/src/main/java/com/memfault/bort/ota/lib/BootCompleteReceiver.kt
@@ -83,7 +83,7 @@ class BootCompleteReceiver : BroadcastReceiver() {
     private fun schedulePeriodicUpdateCheck(context: Context, updateCheckIntervalMs: Long) {
         Logger.d("schedulePeriodicUpdateCheck: $updateCheckIntervalMs")
         val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.UNMETERED)
+            .setRequiredNetworkType(if (BuildConfig.OTA_ALLOW_METERED) NetworkType.CONNECTED else NetworkType.UNMETERED)
             .setRequiresBatteryNotLow(true)
             .setRequiresStorageNotLow(true)
             .build()

--- a/MemfaultPackages/bort-shared/build.gradle
+++ b/MemfaultPackages/bort-shared/build.gradle
@@ -30,6 +30,7 @@ android {
         buildConfigField "String", "CLIENT_SERVER_HOST", "\"" + bortProperty("CLIENT_SERVER_HOST") + "\""
         buildConfigField "Boolean", "OTA_AUTO_INSTALL", bortProperty("OTA_AUTO_INSTALL")
         buildConfigField "String", "MEMFAULT_PROJECT_API_KEY", "\"" + bortProperty("MEMFAULT_PROJECT_API_KEY") + "\""
+        buildConfigField "Boolean", "OTA_ALLOW_METERED", bortProperty("OTA_ALLOW_METERED")
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/MemfaultPackages/bort.properties
+++ b/MemfaultPackages/bort.properties
@@ -72,3 +72,5 @@ CLIENT_SERVER_HOST=127.0.0.1
 # This can be overridden in the Memfault dashboard on a per-release basis.
 # See also: AutoInstallRules.kt.
 OTA_AUTO_INSTALL=false
+# Allow metered OTA check & updates
+OTA_ALLOW_METERED=false


### PR DESCRIPTION
We found that OTA updates are effectively disabled on metered networks (LTE) (as described in [OTA Update Client Behavior](https://docs.memfault.com/docs/android/android-ota-update-client/#ota-update-client-behavior) which doesn't work for an all-LTE device. 

We've incorporated this change downstream but suggesting it to the [`memfault/bort`](https://github.com/memfault/bort) repo as well so the community can benefit. This doesn't take into account any documentation that would have to reflect the new flag.